### PR TITLE
Allow trunk-merge branches to run forever if requested

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -19,3 +19,13 @@ jobs:
 
       - name: build
         run: sleep 2s
+
+      - name: Check run forever file existence
+        id: run_forever
+        uses: andstor/file-existence-action@v1
+        with:
+          files: "test/run_forever.txt"
+
+      - name: Run forever
+        if: steps.run_forever.outputs.files_exists == 'true' && contains('trunk-merge', github.ref)
+        run: sleep 180s

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -22,9 +22,9 @@ jobs:
 
       - name: Check run forever file existence
         id: run_forever
-        uses: andstor/file-existence-action@v1
+        uses: technote-space/get-diff-action@v6
         with:
-          files: "test/run_forever.txt"
+          PATTERNS: test/run_forever*.txt
 
       - name: Run forever
         if: steps.run_forever.outputs.files_exists == 'true' && contains('trunk-merge', github.ref)


### PR DESCRIPTION
Since switching to `on_push`, we don't have any way to allow PRs to run forever if needed (previously, the `mq.yaml` file had code to do that). This will allow `trunk-merge` branches to run forever if we provide the `run_forever` file in the diff

To test this, I added a `test/run_forever_4.txt` file to the diff to see if the step to check for its presence caught it, which it did

![image](https://user-images.githubusercontent.com/28661308/191286639-8ae5264b-8ddd-4cdb-a65e-4a180ba680a7.png)
