### PR TITLE
Correctly check whether we should run forever

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -27,5 +27,5 @@ jobs:
           PATTERNS: test/run_forever*.txt
 
       - name: Run forever
-        if: steps.run_forever.outputs.files_exists == 'true' && contains('trunk-merge', github.ref)
+        if: steps.run_forever.outputs.diff && contains('trunk-merge', github.ref)
         run: sleep 180s


### PR DESCRIPTION
I was incorrectly checking `steps.run_forever.outputs.files_exists == 'true'` but it should be `steps.fail_test.outputs.diff`

Check https://github.com/prawn-test-staging-rw/mergequeue_service_test/pull/43670 for proof as it does the same changes