### PR TITLE
Correctly check for trunk merge branch when running forever

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -12,6 +12,8 @@ jobs:
   pr:
     name: Run Pull Request checks
     runs-on: ubuntu-latest
+    env:
+      BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
 
     steps:
       - name: Checkout code
@@ -27,5 +29,5 @@ jobs:
           PATTERNS: test/run_forever*.txt
 
       - name: Run forever
-        if: steps.run_forever.outputs.diff && contains('trunk-merge', github.ref)
+        if: steps.run_forever.outputs.diff && startsWith(env.BRANCH_NAME, 'trunk-merge')
         run: sleep 180s


### PR DESCRIPTION
I was checking for if the branch was a trunk branch incorrectly - that was my bad.

This shows that the forever check is runnign on trunk branches now - https://github.com/prawn-test-staging-rw/mergequeue_service_test_commit_status/actions/runs/3151849534/jobs/5126328827

You can see here too that the check ran and that the branch is a trunk branch

![image](https://user-images.githubusercontent.com/28661308/193050524-22f866e8-404e-43f5-a1d2-13ca6314e023.png)
