### PR TITLE
Remove buildkite as a required status for MQ

### DIFF
--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -9,7 +9,11 @@ lint:
     - prettier@2.4.1
 merge:
   required_statuses:
-    - buildkite/trunk-merge-smoke-test
+    # Currently, buildkite/trunk-merge-smoke-test is taking a long time
+    # to run / report status to GH, which is causing smoke tests to fail
+    # since MQ won't merge a PR until that check finishes.
+    # Reference - https://trunk-io.slack.com/archives/C0272DLKGLF/p1682604350559439?thread_ts=1682549002.219079&cid=C0272DLKGLF
+    # buildkite/trunk-merge-smoke-test
     - Run Pull Request checks
 version: 0.1
 api:


### PR DESCRIPTION
https://trunk-io.slack.com/archives/C0272DLKGLF/p1682604350559439?thread_ts=1682549002.219079&cid=C0272DLKGLF

Right now, it is taking a long time for buildkite to report its status to GH. Because of this, MQ, during smoke tests, is constantly waiting for the buildkite check to complete as it is a required status and cannot merge a PR without it passing. This is ultimately causing our queue items to sit in the testing state for too long, causing smoke tests to [repeatedly](https://github.com/trunk-io/trunk/actions/runs/4820122592) [and](https://github.com/trunk-io/trunk/actions/runs/4819517253) [consistently](https://github.com/trunk-io/trunk/actions/runs/4819003178) [fail](https://github.com/trunk-io/trunk/actions/runs/4818492374). This is a problem that has also been plaguging us for months but it has never been this bad

_This PR is meant to serve as a temporary band-aid to stop MQ tests from failing repeatedly_. I am not sure why the buildkite check is always pending and what features / improvements should come out of seeing a problem like this.

Example branch that didn't have buildkite report its checks which then resulted in the [smoke tests failing](https://github.com/trunk-io/trunk/actions/runs/4820122592/jobs/8584185313) and its associated [PR](https://github.com/prawn-test-staging-rw/mergequeue_service_test_commit_status/pull/101236) - https://github.com/prawn-test-staging-rw/mergequeue_service_test_commit_status/tree/trunk-merge/100540/23u1jrH2-EeL3
![image](https://user-images.githubusercontent.com/28661308/234891486-871c67dd-b173-440c-9bc5-1dc648830d8a.png)

As a note - we've been experience the same exact failure intermittently for MONTHS - it would just happen every once in a while. Now it is happening all the time
